### PR TITLE
[feature] support pre-release detection

### DIFF
--- a/GameLauncher/GameLauncher.csproj
+++ b/GameLauncher/GameLauncher.csproj
@@ -79,15 +79,15 @@
   <!-- MSIX Package Properties -->
   <PropertyGroup>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
-    <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
+    <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
     <GenerateTestCertificate>True</GenerateTestCertificate>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-    <PackageCertificateThumbprint>8A76AFE0470A082DBDBBD85C1054C27E3A5C2FE4</PackageCertificateThumbprint>
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
     <AppxSymbolPackageEnabled>False</AppxSymbolPackageEnabled>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundle>Auto</AppxBundle>
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
+    <PackageCertificateKeyFile>GameLauncher_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
 </Project>

--- a/GameLauncher/Package.appxmanifest
+++ b/GameLauncher/Package.appxmanifest
@@ -9,8 +9,8 @@
 
   <Identity
     Name="GameLauncher"
-    Publisher="CN=Developer"
-    Version="0.1.1.0" />
+    Publisher="CN=Li"
+    Version="0.2.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="fb617303-b818-4202-b873-8c6eef57e2c2" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/GameLauncher/Pages/SettingsPage.xaml
+++ b/GameLauncher/Pages/SettingsPage.xaml
@@ -69,6 +69,19 @@
                                Opacity="0.7"
                                Margin="0,-8,0,8"/>
 
+                    <!-- Include Prerelease -->
+                    <ToggleSwitch x:Name="IncludePrereleaseToggle" 
+                                  Header="包含预发布版本"
+                                  OnContent="包含" 
+                                  OffContent="仅正式版"
+                                  IsOn="False"
+                                  Toggled="IncludePrereleaseToggle_Toggled"/>
+                    
+                    <TextBlock Text="是否接收预发布版本的更新（可能不稳定）" 
+                               Style="{StaticResource CaptionTextBlockStyle}" 
+                               Opacity="0.7"
+                               Margin="0,-8,0,8"/>
+
                     <!-- Update Frequency -->
                     <StackPanel x:Name="UpdateFrequencyPanel" Spacing="8">
                         <TextBlock Text="检查频率" 

--- a/GameLauncher/Pages/SettingsPage.xaml.cs
+++ b/GameLauncher/Pages/SettingsPage.xaml.cs
@@ -121,12 +121,18 @@ namespace GameLauncher.Pages
                     try
                     {
                         var settings = UpdateSettings.GetSettings();
-                        System.Diagnostics.Debug.WriteLine($"Loading update settings: AutoUpdate={settings.AutoUpdateEnabled}, Frequency={settings.UpdateFrequency}");
+                        System.Diagnostics.Debug.WriteLine($"Loading update settings: AutoUpdate={settings.AutoUpdateEnabled}, Frequency={settings.UpdateFrequency}, IncludePrerelease={settings.IncludePrerelease}");
 
                         // 设置自动更新开关
                         if (AutoUpdateToggle != null)
                         {
                             AutoUpdateToggle.IsOn = settings.AutoUpdateEnabled;
+                        }
+
+                        // 设置预发布版本开关
+                        if (IncludePrereleaseToggle != null)
+                        {
+                            IncludePrereleaseToggle.IsOn = settings.IncludePrerelease;
                         }
 
                         // 设置检查频率
@@ -149,8 +155,8 @@ namespace GameLauncher.Pages
                                 break;
                         }
 
-                        // 根据自动更新状态启用/禁用频率设置
-                        UpdateFrequencyPanelVisibility(settings.AutoUpdateEnabled);
+                        // 根据自动更新状态启用/禁用相关设置
+                        UpdateSettingsPanelVisibility(settings.AutoUpdateEnabled);
                     }
                     catch (Exception ex)
                     {
@@ -199,12 +205,20 @@ namespace GameLauncher.Pages
             }
         }
 
-        private void UpdateFrequencyPanelVisibility(bool isEnabled)
+        private void UpdateSettingsPanelVisibility(bool isEnabled)
         {
+            // 更新频率面板
             if (UpdateFrequencyPanel != null)
             {
                 UpdateFrequencyPanel.Opacity = isEnabled ? 1.0 : 0.5;
                 UpdateFrequencyPanel.IsHitTestVisible = isEnabled;
+            }
+
+            // 预发布版本开关
+            if (IncludePrereleaseToggle != null)
+            {
+                IncludePrereleaseToggle.Opacity = isEnabled ? 1.0 : 0.5;
+                IncludePrereleaseToggle.IsHitTestVisible = isEnabled;
             }
         }
 
@@ -244,8 +258,8 @@ namespace GameLauncher.Pages
                     var isEnabled = toggle.IsOn;
                     System.Diagnostics.Debug.WriteLine($"Auto update toggled: {isEnabled}");
 
-                    // 更新频率面板的可用性
-                    UpdateFrequencyPanelVisibility(isEnabled);
+                    // 更新相关设置的可用性
+                    UpdateSettingsPanelVisibility(isEnabled);
 
                     // 保存设置
                     SaveUpdateSettings();
@@ -294,6 +308,32 @@ namespace GameLauncher.Pages
             }
         }
 
+        private void IncludePrereleaseToggle_Toggled(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (sender is ToggleSwitch toggle)
+                {
+                    var includePrerelease = toggle.IsOn;
+                    System.Diagnostics.Debug.WriteLine($"Include prerelease toggled: {includePrerelease}");
+
+                    // 保存设置
+                    SaveUpdateSettings();
+
+                    // 如果自动更新启用，重新启动检查以应用新设置
+                    if (AutoUpdateToggle?.IsOn == true)
+                    {
+                        UpdateService.StopAutoUpdateCheck();
+                        UpdateService.StartAutoUpdateCheck();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"IncludePrereleaseToggle_Toggled error: {ex}");
+            }
+        }
+
         private async void CheckUpdateButton_Click(object sender, RoutedEventArgs e)
         {
             try
@@ -323,32 +363,11 @@ namespace GameLauncher.Pages
 
                 if (result.HasUpdate)
                 {
-                    var message = $"发现新版本 {result.LatestVersion}，当前版本 {result.CurrentVersion}。\n\n是否立即下载并安装更新？";
-                    var updateDialog = new ContentDialog
-                    {
-                        Title = "发现新版本",
-                        Content = message,
-                        PrimaryButtonText = "立即更新",
-                        SecondaryButtonText = "稍后提醒",
-                        CloseButtonText = "跳过此版本",
-                        XamlRoot = this.XamlRoot
-                    };
-
-                    var dialogResult = await updateDialog.ShowAsync();
-
-                    if (dialogResult == ContentDialogResult.Primary && !string.IsNullOrEmpty(result.DownloadUrl))
-                    {
-                        await PerformUpdateWithProgress(result.DownloadUrl);
-                    }
-                    else if (dialogResult == ContentDialogResult.None) // 用户点击了"跳过此版本"
-                    {
-                        UpdateService.SkipVersion(result.LatestVersion ?? "");
-                        await ShowDialog("版本已跳过", "此版本更新已跳过，如需重新检查请重启应用。");
-                    }
+                    await ShowUpdateDetailsDialog(result);
                 }
                 else
                 {
-                    await ShowDialog("检查更新", "您当前使用的已是最新版本。");
+                    await ShowNoUpdateDialog(result);
                 }
             }
             catch (Exception ex)
@@ -362,6 +381,349 @@ namespace GameLauncher.Pages
                 }
                 
                 await ShowDialog("检查更新失败", $"检查更新时发生错误: {ex.Message}");
+            }
+        }
+
+        private async Task ShowUpdateDetailsDialog(UpdateCheckResult result)
+        {
+            try
+            {
+                // 构建详细的版本信息UI
+                var stackPanel = new StackPanel { Spacing = 16, MaxWidth = 500 };
+
+                // 版本信息区域
+                var versionInfoPanel = new StackPanel { Spacing = 8 };
+                
+                // 标题
+                var titleText = new TextBlock
+                {
+                    Text = result.IsPrerelease ? "发现新的预发布版本" : "发现新版本",
+                    Style = (Style)App.Current.Resources["SubtitleTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center
+                };
+                versionInfoPanel.Children.Add(titleText);
+
+                // 版本对比信息
+                var versionComparePanel = new Grid();
+                versionComparePanel.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                versionComparePanel.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(20) });
+                versionComparePanel.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+                // 当前版本
+                var currentVersionPanel = new StackPanel { HorizontalAlignment = HorizontalAlignment.Center };
+                currentVersionPanel.Children.Add(new TextBlock 
+                { 
+                    Text = "当前版本", 
+                    Style = (Style)App.Current.Resources["CaptionTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Opacity = 0.7
+                });
+                currentVersionPanel.Children.Add(new TextBlock 
+                { 
+                    Text = result.CurrentVersion ?? "未知", 
+                    Style = (Style)App.Current.Resources["BodyStrongTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center
+                });
+                Grid.SetColumn(currentVersionPanel, 0);
+                versionComparePanel.Children.Add(currentVersionPanel);
+
+                // 箭头 - 使用SymbolIcon替代FontIcon
+                var arrowIcon = new SymbolIcon(Symbol.Forward)
+                {
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Opacity = 0.6
+                };
+                Grid.SetColumn(arrowIcon, 1);
+                versionComparePanel.Children.Add(arrowIcon);
+
+                // 最新版本
+                var latestVersionPanel = new StackPanel { HorizontalAlignment = HorizontalAlignment.Center };
+                latestVersionPanel.Children.Add(new TextBlock 
+                { 
+                    Text = result.IsPrerelease ? "最新预发布版本" : "最新版本", 
+                    Style = (Style)App.Current.Resources["CaptionTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Opacity = 0.7
+                });
+                
+                var latestVersionText = new TextBlock 
+                { 
+                    Text = result.LatestVersion ?? "未知", 
+                    Style = (Style)App.Current.Resources["BodyStrongTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center
+                };
+                
+                if (result.IsPrerelease)
+                {
+                    latestVersionText.Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Orange);
+                }
+                
+                latestVersionPanel.Children.Add(latestVersionText);
+                Grid.SetColumn(latestVersionPanel, 2);
+                versionComparePanel.Children.Add(latestVersionPanel);
+
+                versionInfoPanel.Children.Add(versionComparePanel);
+
+                // 预发布版本警告 - 使用SymbolIcon替代FontIcon
+                if (result.IsPrerelease)
+                {
+                    var warningPanel = new StackPanel 
+                    { 
+                        Orientation = Orientation.Horizontal, 
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Spacing = 8
+                    };
+                    
+                    var warningIcon = new SymbolIcon(Symbol.Important)
+                    {
+                        Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Orange),
+                        VerticalAlignment = VerticalAlignment.Center
+                    };
+                    warningPanel.Children.Add(warningIcon);
+                    
+                    warningPanel.Children.Add(new TextBlock 
+                    { 
+                        Text = "这是一个预发布版本，可能包含不稳定的功能", 
+                        Style = (Style)App.Current.Resources["CaptionTextBlockStyle"],
+                        Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Orange),
+                        VerticalAlignment = VerticalAlignment.Center
+                    });
+                    
+                    versionInfoPanel.Children.Add(warningPanel);
+                }
+
+                stackPanel.Children.Add(versionInfoPanel);
+
+                // 发布说明
+                if (!string.IsNullOrWhiteSpace(result.ReleaseNotes))
+                {
+                    var releaseNotesPanel = new StackPanel { Spacing = 8 };
+                    
+                    releaseNotesPanel.Children.Add(new TextBlock 
+                    { 
+                        Text = "更新内容", 
+                        Style = (Style)App.Current.Resources["BodyStrongTextBlockStyle"] 
+                    });
+
+                    var scrollViewer = new ScrollViewer 
+                    { 
+                        MaxHeight = 150,
+                        VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                        HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled
+                    };
+
+                    var releaseNotesText = new TextBlock 
+                    { 
+                        Text = result.ReleaseNotes.Trim(),
+                        Style = (Style)App.Current.Resources["CaptionTextBlockStyle"],
+                        TextWrapping = TextWrapping.Wrap,
+                        IsTextSelectionEnabled = true,
+                        Opacity = 0.8
+                    };
+
+                    scrollViewer.Content = releaseNotesText;
+                    releaseNotesPanel.Children.Add(scrollViewer);
+                    stackPanel.Children.Add(releaseNotesPanel);
+                }
+
+                // 操作提示
+                var actionText = new TextBlock 
+                { 
+                    Text = "是否立即下载并安装更新？",
+                    Style = (Style)App.Current.Resources["BodyTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Margin = new Thickness(0, 8, 0, 0)
+                };
+                stackPanel.Children.Add(actionText);
+
+                var updateDialog = new ContentDialog
+                {
+                    Title = result.IsPrerelease ? "发现新的预发布版本" : "发现新版本",
+                    Content = stackPanel,
+                    PrimaryButtonText = "立即更新",
+                    SecondaryButtonText = "稍后提醒",
+                    CloseButtonText = "跳过此版本",
+                    XamlRoot = this.XamlRoot
+                };
+
+                var dialogResult = await updateDialog.ShowAsync();
+
+                if (dialogResult == ContentDialogResult.Primary && !string.IsNullOrEmpty(result.DownloadUrl))
+                {
+                    await PerformUpdateWithProgress(result.DownloadUrl);
+                }
+                else if (dialogResult == ContentDialogResult.None) // 用户点击了"跳过此版本"
+                {
+                    UpdateService.SkipVersion(result.LatestVersion ?? "");
+                    await ShowDialog("版本已跳过", "此版本更新已跳过，如需重新检查请重启应用。");
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"ShowUpdateDetailsDialog error: {ex}");
+                await ShowDialog("显示更新信息失败", $"显示更新详情时发生错误: {ex.Message}");
+            }
+        }
+
+        private async Task ShowNoUpdateDialog(UpdateCheckResult result)
+        {
+            try
+            {
+                // 构建无更新信息UI，包含远端版本信息用于调试
+                var stackPanel = new StackPanel { Spacing = 16, MaxWidth = 450 };
+
+                // 成功图标和标题
+                var headerPanel = new StackPanel { Spacing = 8, HorizontalAlignment = HorizontalAlignment.Center };
+                
+                var successIcon = new SymbolIcon(Symbol.Accept)
+                {
+                    Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Green),
+                    HorizontalAlignment = HorizontalAlignment.Center
+                };
+                headerPanel.Children.Add(successIcon);
+
+                headerPanel.Children.Add(new TextBlock 
+                { 
+                    Text = "您使用的已是最新版本", 
+                    Style = (Style)App.Current.Resources["SubtitleTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center
+                });
+
+                stackPanel.Children.Add(headerPanel);
+
+                // 版本信息对比 - 显示当前版本和远端版本
+                var versionComparePanel = new Grid();
+                versionComparePanel.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                versionComparePanel.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(20) });
+                versionComparePanel.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+                // 当前版本
+                var currentVersionPanel = new StackPanel { HorizontalAlignment = HorizontalAlignment.Center };
+                currentVersionPanel.Children.Add(new TextBlock 
+                { 
+                    Text = "当前版本", 
+                    Style = (Style)App.Current.Resources["CaptionTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Opacity = 0.7
+                });
+                currentVersionPanel.Children.Add(new TextBlock 
+                { 
+                    Text = result.CurrentVersion ?? "未知", 
+                    Style = (Style)App.Current.Resources["BodyStrongTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center
+                });
+                Grid.SetColumn(currentVersionPanel, 0);
+                versionComparePanel.Children.Add(currentVersionPanel);
+
+                // 等于号图标
+                var equalText = new TextBlock
+                {
+                    Text = "=",
+                    FontSize = 18,
+                    FontWeight = Microsoft.UI.Text.FontWeights.Bold,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Opacity = 0.6
+                };
+                Grid.SetColumn(equalText, 1);
+                versionComparePanel.Children.Add(equalText);
+
+                // 远端版本
+                var remoteVersionPanel = new StackPanel { HorizontalAlignment = HorizontalAlignment.Center };
+                remoteVersionPanel.Children.Add(new TextBlock 
+                { 
+                    Text = result.IsPrerelease ? "远端预发布版本" : "远端最新版本", 
+                    Style = (Style)App.Current.Resources["CaptionTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Opacity = 0.7
+                });
+                
+                var remoteVersionText = new TextBlock 
+                { 
+                    Text = result.LatestVersion ?? "未知", 
+                    Style = (Style)App.Current.Resources["BodyStrongTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center
+                };
+                
+                if (result.IsPrerelease)
+                {
+                    remoteVersionText.Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Orange);
+                }
+                
+                remoteVersionPanel.Children.Add(remoteVersionText);
+                Grid.SetColumn(remoteVersionPanel, 2);
+                versionComparePanel.Children.Add(remoteVersionPanel);
+
+                stackPanel.Children.Add(versionComparePanel);
+
+                // 预发布版本说明
+                if (result.IsPrerelease)
+                {
+                    var prereleaseInfoPanel = new StackPanel 
+                    { 
+                        Orientation = Orientation.Horizontal, 
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Spacing = 8
+                    };
+                    
+                    var infoIcon = new SymbolIcon(Symbol.Help)
+                    {
+                        Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Orange),
+                        VerticalAlignment = VerticalAlignment.Center
+                    };
+                    prereleaseInfoPanel.Children.Add(infoIcon);
+                    
+                    prereleaseInfoPanel.Children.Add(new TextBlock 
+                    { 
+                        Text = "已启用预发布版本检测", 
+                        Style = (Style)App.Current.Resources["CaptionTextBlockStyle"],
+                        Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Orange),
+                        VerticalAlignment = VerticalAlignment.Center
+                    });
+                    
+                    stackPanel.Children.Add(prereleaseInfoPanel);
+                }
+
+                // 调试信息
+                var debugInfoPanel = new StackPanel { Spacing = 4 };
+                debugInfoPanel.Children.Add(new TextBlock 
+                { 
+                    Text = "调试信息", 
+                    Style = (Style)App.Current.Resources["CaptionTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Opacity = 0.5
+                });
+
+                var debugText = $"检查类型: {(result.IsPrerelease ? "包含预发布版本" : "仅正式版本")}\n" +
+                               $"远端版本: {result.LatestVersion ?? "未获取"}\n" +
+                               $"版本类型: {(result.IsPrerelease ? "预发布版本" : "正式版本")}";
+
+                debugInfoPanel.Children.Add(new TextBlock 
+                { 
+                    Text = debugText,
+                    Style = (Style)App.Current.Resources["CaptionTextBlockStyle"],
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Opacity = 0.4,
+                    FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas")
+                });
+
+                stackPanel.Children.Add(debugInfoPanel);
+
+                var dialog = new ContentDialog
+                {
+                    Title = "检查更新",
+                    Content = stackPanel,
+                    CloseButtonText = "确定",
+                    XamlRoot = this.XamlRoot
+                };
+
+                await dialog.ShowAsync();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"ShowNoUpdateDialog error: {ex}");
+                await ShowDialog("检查更新", "您当前使用的已是最新版本。");
             }
         }
 
@@ -448,6 +810,7 @@ namespace GameLauncher.Pages
             try
             {
                 var autoUpdateEnabled = AutoUpdateToggle?.IsOn ?? false;
+                var includePrerelease = IncludePrereleaseToggle?.IsOn ?? false;
                 
                 var updateFrequency = UpdateFrequency.OnStartup;
                 if (WeeklyRadio?.IsChecked == true)
@@ -455,8 +818,8 @@ namespace GameLauncher.Pages
                     updateFrequency = UpdateFrequency.Weekly;
                 }
 
-                UpdateSettings.SaveSettings(autoUpdateEnabled, updateFrequency);
-                System.Diagnostics.Debug.WriteLine($"Update settings saved: AutoUpdate={autoUpdateEnabled}, Frequency={updateFrequency}");
+                UpdateSettings.SaveSettings(autoUpdateEnabled, updateFrequency, includePrerelease);
+                System.Diagnostics.Debug.WriteLine($"Update settings saved: AutoUpdate={autoUpdateEnabled}, Frequency={updateFrequency}, IncludePrerelease={includePrerelease}");
             }
             catch (Exception ex)
             {

--- a/GameLauncher/Services/UpdateSettings.cs
+++ b/GameLauncher/Services/UpdateSettings.cs
@@ -13,9 +13,11 @@ namespace GameLauncher.Services
     {
         private const string AutoUpdateEnabledKey = "AutoUpdateEnabled";
         private const string UpdateFrequencyKey = "UpdateFrequency";
+        private const string IncludePrereleaseKey = "IncludePrerelease"; // 新增：是否包含预发布版本
 
         public bool AutoUpdateEnabled { get; set; } = true; // 默认启用自动更新
         public UpdateFrequency UpdateFrequency { get; set; } = UpdateFrequency.OnStartup; // 默认每次启动检查
+        public bool IncludePrerelease { get; set; } = false; // 默认不包含预发布版本
 
         public static UpdateSettings GetSettings()
         {
@@ -25,6 +27,7 @@ namespace GameLauncher.Services
                 
                 var autoUpdateEnabled = localSettings.Values[AutoUpdateEnabledKey] as bool? ?? true;
                 var updateFrequencyValue = localSettings.Values[UpdateFrequencyKey] as string ?? "OnStartup";
+                var includePrerelease = localSettings.Values[IncludePrereleaseKey] as bool? ?? false;
                 
                 if (!Enum.TryParse<UpdateFrequency>(updateFrequencyValue, out var updateFrequency))
                 {
@@ -34,7 +37,8 @@ namespace GameLauncher.Services
                 return new UpdateSettings
                 {
                     AutoUpdateEnabled = autoUpdateEnabled,
-                    UpdateFrequency = updateFrequency
+                    UpdateFrequency = updateFrequency,
+                    IncludePrerelease = includePrerelease
                 };
             }
             catch (Exception ex)
@@ -51,8 +55,9 @@ namespace GameLauncher.Services
                 var localSettings = ApplicationData.Current.LocalSettings;
                 localSettings.Values[AutoUpdateEnabledKey] = AutoUpdateEnabled;
                 localSettings.Values[UpdateFrequencyKey] = UpdateFrequency.ToString();
+                localSettings.Values[IncludePrereleaseKey] = IncludePrerelease;
                 
-                System.Diagnostics.Debug.WriteLine($"UpdateSettings saved: AutoUpdate={AutoUpdateEnabled}, Frequency={UpdateFrequency}");
+                System.Diagnostics.Debug.WriteLine($"UpdateSettings saved: AutoUpdate={AutoUpdateEnabled}, Frequency={UpdateFrequency}, IncludePrerelease={IncludePrerelease}");
             }
             catch (Exception ex)
             {
@@ -60,12 +65,13 @@ namespace GameLauncher.Services
             }
         }
 
-        public static void SaveSettings(bool autoUpdateEnabled, UpdateFrequency updateFrequency)
+        public static void SaveSettings(bool autoUpdateEnabled, UpdateFrequency updateFrequency, bool includePrerelease = false)
         {
             var settings = new UpdateSettings
             {
                 AutoUpdateEnabled = autoUpdateEnabled,
-                UpdateFrequency = updateFrequency
+                UpdateFrequency = updateFrequency,
+                IncludePrerelease = includePrerelease
             };
             
             settings.SaveSettings();


### PR DESCRIPTION
#14 

在 `GameLauncher.csproj` 中，将 `AppxAutoIncrementPackageRevision` 属性更改为 `True`，并添加证书文件属性。 在 `Package.appxmanifest` 中更新了 `Publisher` 和 `Version`。 在 `SettingsPage.xaml` 中添加了 `IncludePrereleaseToggle` 切换开关，允许用户选择是否包含预发布版本更新。 在 `SettingsPage.xaml.cs` 中更新了加载和保存设置的逻辑以支持新选项。
在 `UpdateService.cs` 中添加了对 GitHub API 的调用，以获取所有版本的更新信息。 在 `UpdateSettings.cs` 中添加了 `IncludePrerelease` 属性，并更新了相关方法以支持持久化存储。