### PR TITLE
Add support fot Xbox games #5

### DIFF
--- a/GameLauncher/CustomDataObject.cs
+++ b/GameLauncher/CustomDataObject.cs
@@ -12,6 +12,8 @@ namespace GameLauncher
         private BitmapImage? _iconImage;
         private string _steamAppId = string.Empty;
         private bool _isSteamGame = false;
+        private string _xboxPackageFamilyName = string.Empty;
+        private bool _isXboxGame = false;
         private int _displayOrder = 0;
         private string _categoryId = string.Empty;
         private string _category = "未分类";
@@ -56,7 +58,7 @@ namespace GameLauncher
         }
 
         /// <summary>
-        /// Steam AppID (仅用于 Steam 游戏)
+        /// Steam AppID (仅适用于 Steam 游戏)
         /// </summary>
         public string SteamAppId
         {
@@ -88,7 +90,39 @@ namespace GameLauncher
         }
 
         /// <summary>
-        /// 显示顺序，用于保存用户拖拽排序结果
+        /// Xbox Package Family Name (仅适用于 Xbox 游戏)
+        /// </summary>
+        public string XboxPackageFamilyName
+        {
+            get => _xboxPackageFamilyName;
+            set
+            {
+                if (_xboxPackageFamilyName != value)
+                {
+                    _xboxPackageFamilyName = value ?? string.Empty;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// 是否为 Xbox 游戏
+        /// </summary>
+        public bool IsXboxGame
+        {
+            get => _isXboxGame;
+            set
+            {
+                if (_isXboxGame != value)
+                {
+                    _isXboxGame = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// 显示顺序，用于保存用户拖拽排序
         /// </summary>
         public int DisplayOrder
         {
@@ -137,7 +171,7 @@ namespace GameLauncher
         }
 
         /// <summary>
-        /// 分类颜色（十六进制颜色代码）
+        /// 分类颜色（十六进制颜色字符串）
         /// </summary>
         public string CategoryColor
         {

--- a/GameLauncher/Examples/XboxServiceExample.cs
+++ b/GameLauncher/Examples/XboxServiceExample.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading.Tasks;
+using GameLauncher.Services;
+
+namespace GameLauncher.Examples
+{
+    /// <summary>
+    /// Xbox 服务使用示例
+    /// </summary>
+    public static class XboxServiceExample
+    {
+        /// <summary>
+        /// 演示如何使用 Xbox 服务
+        /// </summary>
+        public static async Task RunExampleAsync()
+        {
+            Console.WriteLine("=== Xbox 服务功能演示 ===");
+
+            // 1. 检查 Xbox Pass 应用是否安装
+            Console.WriteLine($"Xbox Pass App 安装状态: {XboxService.IsXboxPassAppInstalled}");
+
+            // 2. 扫描 Xbox 游戏
+            Console.WriteLine("\n开始扫描 Xbox 游戏...");
+            var games = await XboxService.ScanXboxGamesAsync();
+            
+            Console.WriteLine($"\n找到 {games.Count} 个 Xbox 游戏:");
+            foreach (var game in games)
+            {
+                Console.WriteLine($"- {game.Name}");
+                Console.WriteLine($"  ID: {game.AppId}");
+                Console.WriteLine($"  安装位置: {game.InstallLocation}");
+                Console.WriteLine($"  可执行文件: {game.ExecutablePath}");
+                Console.WriteLine($"  发布商: {game.Publisher}");
+                Console.WriteLine($"  版本: {game.Version}");
+                Console.WriteLine();
+            }
+
+            // 3. 演示游戏启动功能
+            if (games.Count > 0)
+            {
+                var firstGame = games[0];
+                Console.WriteLine($"演示启动游戏: {firstGame.Name}");
+                
+                // 检查游戏是否正在运行
+                var isRunning = XboxService.IsGameRunning(firstGame);
+                Console.WriteLine($"游戏运行状态: {(isRunning ? "运行中" : "未运行")}");
+
+                // 获取启动参数
+                var launchArgs = XboxService.GetGameLaunchArguments(firstGame);
+                Console.WriteLine($"启动参数: {launchArgs}");
+
+                // 实际启动游戏（注释掉以避免意外启动）
+                // var launched = XboxService.LaunchXboxGame(firstGame.PackageFamilyName);
+                // Console.WriteLine($"启动结果: {(launched ? "成功" : "失败")}");
+            }
+
+            // 4. 演示打开 Xbox Pass 应用
+            Console.WriteLine("\n演示打开 Xbox Pass 应用:");
+            if (XboxService.IsXboxPassAppInstalled)
+            {
+                // 实际打开应用（注释掉以避免意外打开）
+                // var opened = XboxService.OpenXboxPassApp();
+                // Console.WriteLine($"打开结果: {(opened ? "成功" : "失败")}");
+                Console.WriteLine("Xbox Pass 应用已安装，可以打开");
+            }
+            else
+            {
+                Console.WriteLine("Xbox Pass 应用未安装");
+            }
+
+            Console.WriteLine("\n=== Xbox 服务演示完成 ===");
+        }
+    }
+}

--- a/GameLauncher/Models/UwpApp.cs
+++ b/GameLauncher/Models/UwpApp.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace GameLauncher.Models
+{
+    public class UwpApp
+    {
+        public string AppId { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Path { get; set; } = string.Empty;
+        public string Arguments { get; set; } = string.Empty;
+        public string WorkDir { get; set; } = string.Empty;
+        public string Icon { get; set; } = string.Empty;
+        public bool IsGame { get; set; }
+    }
+}

--- a/GameLauncher/Pages/GamesPage.xaml
+++ b/GameLauncher/Pages/GamesPage.xaml
@@ -171,15 +171,27 @@
                     </StackPanel>
                 </Button>
                 
-                <!-- Import Steam Games Button -->
-                <Button x:Name="ImportSteamGamesButton" 
-                        Click="ImportSteamGamesButton_Click" 
-                        Style="{StaticResource DefaultButtonStyle}">
+                <!-- Import Games DropDownButton -->
+                <DropDownButton x:Name="ImportGamesDropDownButton" Style="{StaticResource DefaultButtonStyle}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <FontIcon Glyph="&#xE896;" FontSize="16"/>
-                        <TextBlock Text="导入Steam游戏"/>
+                        <TextBlock Text="导入游戏"/>
                     </StackPanel>
-                </Button>
+                    <DropDownButton.Flyout>
+                        <MenuFlyout>
+                            <MenuFlyoutItem x:Name="ImportSteamGamesMenuItem" Text="导入Steam游戏" Click="ImportSteamGamesMenuItem_Click">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE968;"/>
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem x:Name="ImportXboxGamesMenuItem" Text="导入Xbox游戏" Click="ImportXboxGamesMenuItem_Click">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE990;"/>
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                        </MenuFlyout>
+                    </DropDownButton.Flyout>
+                </DropDownButton>
                         
                 <!-- Add Game Button -->
                 <Button x:Name="AddGameButton" Content="添加游戏" 

--- a/GameLauncher/Services/Programs.cs
+++ b/GameLauncher/Services/Programs.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Win32;
+using System.Diagnostics;
+using GameLauncher.Models;
+
+namespace GameLauncher.Services
+{
+    public static class Programs
+    {
+        private const string UwpAppsRegistryPath = @"SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\Repository\Packages";
+
+        /// <summary>
+        /// 获取所有已安装的 UWP 应用程序
+        /// </summary>
+        /// <returns>UWP 应用程序列表</returns>
+        public static List<UwpApp> GetUWPApps()
+        {
+            var apps = new List<UwpApp>();
+
+            try
+            {
+                using var key = Registry.CurrentUser.OpenSubKey(UwpAppsRegistryPath);
+                if (key == null)
+                {
+                    System.Diagnostics.Debug.WriteLine("无法打开 UWP 应用注册表键");
+                    return apps;
+                }
+
+                foreach (var subKeyName in key.GetSubKeyNames())
+                {
+                    try
+                    {
+                        using var packageKey = key.OpenSubKey(subKeyName);
+                        if (packageKey == null) continue;
+
+                        var packageRootFolder = packageKey.GetValue("PackageRootFolder") as string;
+                        var packageName = packageKey.GetValue("PackageName") as string;
+                        
+                        if (string.IsNullOrEmpty(packageRootFolder) || string.IsNullOrEmpty(packageName))
+                            continue;
+
+                        // 检查包是否为游戏或应用
+                        var manifestPath = Path.Combine(packageRootFolder, "AppxManifest.xml");
+                        if (!File.Exists(manifestPath))
+                            continue;
+
+                        var appInfo = ParseAppxManifest(manifestPath);
+                        if (appInfo != null)
+                        {
+                            appInfo.AppId = packageName;
+                            appInfo.WorkDir = packageRootFolder;
+                            apps.Add(appInfo);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"处理 UWP 包时出错: {subKeyName} - {ex.Message}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"获取 UWP 应用时出错: {ex.Message}");
+            }
+
+            return apps;
+        }
+
+        /// <summary>
+        /// 解析 AppxManifest.xml 文件
+        /// </summary>
+        private static UwpApp ParseAppxManifest(string manifestPath)
+        {
+            try
+            {
+                var content = File.ReadAllText(manifestPath);
+                
+                // 简单的XML解析，提取应用信息
+                var displayName = ExtractXmlValue(content, "DisplayName");
+                var executable = ExtractXmlValue(content, "Executable");
+                var isGame = content.Contains("Category=\"games\"", StringComparison.OrdinalIgnoreCase) ||
+                           content.Contains("windows.game", StringComparison.OrdinalIgnoreCase);
+
+                if (string.IsNullOrEmpty(displayName))
+                    return null;
+
+                var app = new UwpApp
+                {
+                    Name = displayName,
+                    IsGame = isGame
+                };
+
+                if (!string.IsNullOrEmpty(executable))
+                {
+                    app.Path = Path.Combine(Path.GetDirectoryName(manifestPath), executable);
+                }
+
+                return app;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"解析清单文件时出错: {manifestPath} - {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// 从XML内容中提取指定标签的值
+        /// </summary>
+        private static string ExtractXmlValue(string xmlContent, string tagName)
+        {
+            try
+            {
+                var patterns = new[]
+                {
+                    $@"<{tagName}>([^<]+)</{tagName}>",
+                    $@"{tagName}\s*=\s*""([^""]+)""",
+                    $@"{tagName}\s*=\s*'([^']+)'"
+                };
+
+                foreach (var pattern in patterns)
+                {
+                    var match = System.Text.RegularExpressions.Regex.Match(xmlContent, pattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+                    if (match.Success && match.Groups.Count > 1)
+                    {
+                        return match.Groups[1].Value.Trim();
+                    }
+                }
+
+                return string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/GameLauncher/Services/XboxService.cs
+++ b/GameLauncher/Services/XboxService.cs
@@ -1,0 +1,839 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Win32;
+using System.Diagnostics;
+using System.Xml.Linq;
+using GameLauncher.Models;
+
+namespace GameLauncher.Services
+{
+    public class XboxGame
+    {
+        public string PackageFamilyName { get; set; } = string.Empty;
+        public string AppId { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string InstallLocation { get; set; } = string.Empty;
+        public string ExecutablePath { get; set; } = string.Empty;
+        public string IconPath { get; set; } = string.Empty;
+        public bool IsInstalled { get; set; }
+        public string Version { get; set; } = string.Empty;
+        public string Publisher { get; set; } = string.Empty;
+        public DateTime? LastActivity { get; set; }
+        public ulong Playtime { get; set; } // 游戏时长（秒）
+    }
+
+    public static class XboxService
+    {
+        private const string XboxPassAppFamilyName = "Microsoft.GamingApp_8wekyb3d8bbwe";
+        private static bool? _isXboxPassAppInstalled;
+
+        /// <summary>
+        /// 检查 Xbox PC Pass 应用是否已安装
+        /// </summary>
+        public static bool IsXboxPassAppInstalled
+        {
+            get
+            {
+                if (_isXboxPassAppInstalled.HasValue)
+                    return _isXboxPassAppInstalled.Value;
+
+                try
+                {
+                    var uwpApps = Programs.GetUWPApps();
+                    var xboxApp = uwpApps.FirstOrDefault(app => app.AppId == XboxPassAppFamilyName);
+                    _isXboxPassAppInstalled = xboxApp != null;
+                    
+                    System.Diagnostics.Debug.WriteLine($"Xbox Pass App 安装状态: {_isXboxPassAppInstalled}");
+                    return _isXboxPassAppInstalled.Value;
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"检查 Xbox Pass App 时出错: {ex.Message}");
+                    _isXboxPassAppInstalled = false;
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// 打开 Xbox PC Pass 应用
+        /// </summary>
+        public static bool OpenXboxPassApp()
+        {
+            try
+            {
+                var uwpApps = Programs.GetUWPApps();
+                var xboxApp = uwpApps.FirstOrDefault(app => app.AppId == XboxPassAppFamilyName);
+                
+                if (xboxApp == null)
+                {
+                    System.Diagnostics.Debug.WriteLine("Xbox PC Pass 应用未安装");
+                    return false;
+                }
+
+                if (!string.IsNullOrEmpty(xboxApp.Path))
+                {
+                    var startInfo = new ProcessStartInfo
+                    {
+                        FileName = xboxApp.Path,
+                        Arguments = xboxApp.Arguments,
+                        UseShellExecute = true
+                    };
+                    Process.Start(startInfo);
+                }
+                else
+                {
+                    // 使用协议启动
+                    var startInfo = new ProcessStartInfo
+                    {
+                        FileName = "explorer.exe",
+                        Arguments = $"shell:appsFolder\\{XboxPassAppFamilyName}!App",
+                        UseShellExecute = true
+                    };
+                    Process.Start(startInfo);
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"打开 Xbox Pass App 时出错: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// 扫描 Xbox 游戏 - 整合 UWP 和目录扫描
+        /// </summary>
+        public static async Task<List<XboxGame>> ScanXboxGamesAsync()
+        {
+            var games = new List<XboxGame>();
+            var foundIdentifiers = new HashSet<string>();
+
+            System.Diagnostics.Debug.WriteLine("=== 开始全面扫描 Xbox 游戏 ===");
+
+            // 方法1: 扫描已安装的 UWP Xbox 游戏
+            await ScanInstalledXboxUwpGamesAsync(games, foundIdentifiers);
+
+            // 方法2: 扫描所有驱动器的 XboxGames 目录
+            await ScanXboxGamesDirectoriesAsync(games, foundIdentifiers);
+
+            // 方法3: 通过注册表查找Xbox游戏安装路径
+            await ScanXboxRegistryLocationsAsync(games, foundIdentifiers);
+
+            System.Diagnostics.Debug.WriteLine($"=== Xbox 游戏扫描完成，总共找到 {games.Count} 个游戏 ===");
+            
+            // 按名称排序并返回
+            return games.OrderBy(g => g.Name).ToList();
+        }
+
+        /// <summary>
+        /// 扫描已安装的 UWP Xbox 游戏
+        /// </summary>
+        private static async Task ScanInstalledXboxUwpGamesAsync(List<XboxGame> games, HashSet<string> foundIdentifiers)
+        {
+            try
+            {
+                System.Diagnostics.Debug.WriteLine("--- 开始扫描 UWP Xbox 游戏 ---");
+
+                var uwpApps = Programs.GetUWPApps();
+                var xboxGames = uwpApps.Where(app => app.IsGame && IsXboxRelatedApp(app)).ToList();
+
+                foreach (var uwpGame in xboxGames)
+                {
+                    try
+                    {
+                        var game = CreateGameFromUwpApp(uwpGame);
+                        if (game != null && !foundIdentifiers.Contains(game.AppId))
+                        {
+                            games.Add(game);
+                            foundIdentifiers.Add(game.AppId);
+                            System.Diagnostics.Debug.WriteLine($"通过 UWP 找到Xbox游戏: {game.Name}");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"处理 UWP Xbox 游戏时出错: {uwpGame.Name} - {ex.Message}");
+                    }
+                }
+
+                await Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"扫描 UWP Xbox 游戏时出错: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 判断 UWP 应用是否为 Xbox 相关游戏
+        /// </summary>
+        private static bool IsXboxRelatedApp(UwpApp app)
+        {
+            if (!app.IsGame)
+                return false;
+
+            // 检查是否安装在 Xbox 相关目录
+            if (!string.IsNullOrEmpty(app.WorkDir))
+            {
+                var lowerPath = app.WorkDir.ToLowerInvariant();
+                if (lowerPath.Contains("xboxgames") || 
+                    lowerPath.Contains("modifiablewindowsapps") ||
+                    lowerPath.Contains("xbox"))
+                {
+                    return true;
+                }
+            }
+
+            // 检查应用ID是否包含已知的Xbox游戏发布商
+            var xboxPublishers = new[]
+            {
+                "microsoft", "xbox", "8wekyb3d8bbwe" // Microsoft的发布商ID
+            };
+
+            return xboxPublishers.Any(pub => app.AppId.ToLowerInvariant().Contains(pub));
+        }
+
+        /// <summary>
+        /// 从 UWP 应用创建 Xbox 游戏对象
+        /// </summary>
+        private static XboxGame CreateGameFromUwpApp(UwpApp uwpApp)
+        {
+            try
+            {
+                // 尝试从安装目录找到最佳的可执行文件
+                var executablePath = FindXboxGameExecutable(uwpApp.WorkDir, uwpApp.Name);
+                if (string.IsNullOrEmpty(executablePath) && !string.IsNullOrEmpty(uwpApp.Path))
+                {
+                    executablePath = uwpApp.Path;
+                }
+
+                return new XboxGame
+                {
+                    PackageFamilyName = uwpApp.AppId,
+                    AppId = uwpApp.AppId,
+                    Name = CleanGameName(uwpApp.Name),
+                    InstallLocation = uwpApp.WorkDir,
+                    ExecutablePath = executablePath,
+                    IconPath = uwpApp.Icon,
+                    IsInstalled = true,
+                    Version = "Unknown",
+                    Publisher = "Microsoft"
+                };
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"从 UWP 应用创建游戏对象时出错: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// 清理游戏名称，移除常见后缀
+        /// </summary>
+        private static string CleanGameName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return name;
+
+            return name
+                .Replace("(PC)", "")
+                .Replace("(Windows)", "")
+                .Replace("for Windows 10", "")
+                .Replace("- Windows 10", "")
+                .Replace("?", "")
+                .Replace("?", "")
+                .Trim();
+        }
+
+        /// <summary>
+        /// 扫描所有驱动器的 XboxGames 目录
+        /// </summary>
+        private static async Task ScanXboxGamesDirectoriesAsync(List<XboxGame> games, HashSet<string> foundIdentifiers)
+        {
+            try
+            {
+                System.Diagnostics.Debug.WriteLine("--- 开始扫描 XboxGames 目录 ---");
+
+                var xboxGamesPaths = new List<string>();
+
+                // 获取所有固定驱动器
+                var drives = DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.Fixed && d.IsReady);
+
+                foreach (var drive in drives)
+                {
+                    var possibleXboxPaths = new[]
+                    {
+                        // 主要的XboxGames目录位置
+                        Path.Combine(drive.RootDirectory.FullName, "XboxGames"),
+                        
+                        // 可能的其他Xbox游戏目录
+                        Path.Combine(drive.RootDirectory.FullName, "Program Files", "XboxGames"),
+                        Path.Combine(drive.RootDirectory.FullName, "Program Files (x86)", "XboxGames")
+                    };
+
+                    foreach (var path in possibleXboxPaths)
+                    {
+                        if (Directory.Exists(path))
+                        {
+                            xboxGamesPaths.Add(path);
+                            System.Diagnostics.Debug.WriteLine($"找到 Xbox 游戏目录: {path}");
+                        }
+                    }
+                }
+
+                // 并行扫描所有找到的Xbox游戏目录
+                await Task.WhenAll(xboxGamesPaths.Select(async path => 
+                    await ScanXboxGamesInDirectoryAsync(path, games, foundIdentifiers)));
+
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"扫描 XboxGames 目录时出错: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 扫描Xbox注册表位置
+        /// </summary>
+        private static async Task ScanXboxRegistryLocationsAsync(List<XboxGame> games, HashSet<string> foundIdentifiers)
+        {
+            try
+            {
+                System.Diagnostics.Debug.WriteLine("--- 开始扫描 Xbox 注册表位置 ---");
+
+                var registryPaths = new[]
+                {
+                    @"Software\Microsoft\GamingServices",
+                    @"Software\Microsoft\Windows\CurrentVersion\GameDVR\KnownGames",
+                    @"Software\Microsoft\XboxLive\Games"
+                };
+
+                foreach (var registryPath in registryPaths)
+                {
+                    await ScanXboxRegistryPathAsync(registryPath, games, foundIdentifiers);
+                }
+
+                // 获取从注册表中的Xbox游戏安装目录
+                var xboxInstallDirs = GetXboxInstallDirectoriesFromRegistry();
+                foreach (var dir in xboxInstallDirs)
+                {
+                    await ScanXboxGamesInDirectoryAsync(dir, games, foundIdentifiers);
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"扫描Xbox注册表时出错: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 专门扫描XboxGames目录中的游戏
+        /// </summary>
+        private static async Task ScanXboxGamesInDirectoryAsync(string xboxGamesDirectory, List<XboxGame> games, HashSet<string> foundIdentifiers)
+        {
+            try
+            {
+                if (!Directory.Exists(xboxGamesDirectory))
+                    return;
+
+                System.Diagnostics.Debug.WriteLine($"扫描Xbox游戏目录: {xboxGamesDirectory}");
+
+                var gameDirectories = Directory.GetDirectories(xboxGamesDirectory);
+                
+                await Task.Run(() =>
+                {
+                    Parallel.ForEach(gameDirectories, gameDir =>
+                    {
+                        try
+                        {
+                            var game = CreateXboxGameFromDirectory(gameDir);
+                            if (game != null)
+                            {
+                                var identifier = !string.IsNullOrEmpty(game.PackageFamilyName) 
+                                    ? game.PackageFamilyName 
+                                    : $"Xbox_{game.Name}_{Path.GetFileName(gameDir)}".GetHashCode().ToString();
+
+                                lock (foundIdentifiers)
+                                {
+                                    if (!foundIdentifiers.Contains(identifier))
+                                    {
+                                        games.Add(game);
+                                        foundIdentifiers.Add(identifier);
+                                        System.Diagnostics.Debug.WriteLine($"在 {Path.GetFileName(xboxGamesDirectory)} 中找到Xbox游戏: {game.Name}");
+                                    }
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            System.Diagnostics.Debug.WriteLine($"处理Xbox游戏目录时出错: {gameDir} - {ex.Message}");
+                        }
+                    });
+                });
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"扫描Xbox游戏目录时出错: {xboxGamesDirectory} - {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 从XboxGames目录创建游戏对象
+        /// </summary>
+        private static XboxGame? CreateXboxGameFromDirectory(string gameDirectory)
+        {
+            try
+            {
+                if (!Directory.Exists(gameDirectory))
+                    return null;
+
+                var directoryName = Path.GetFileName(gameDirectory);
+                
+                // 首先尝试从AppxManifest.xml获取信息
+                var manifestPath = Path.Combine(gameDirectory, "AppxManifest.xml");
+                if (File.Exists(manifestPath))
+                {
+                    var gameFromManifest = CreateGameFromXboxManifest(manifestPath, gameDirectory);
+                    if (gameFromManifest != null)
+                        return gameFromManifest;
+                }
+
+                // 检查是否有游戏可执行文件
+                var executablePath = FindXboxGameExecutable(gameDirectory, directoryName);
+                if (string.IsNullOrEmpty(executablePath))
+                    return null;
+
+                // 尝试从目录结构推断游戏信息
+                var gameName = ExtractGameNameFromDirectory(gameDirectory, directoryName);
+
+                return new XboxGame
+                {
+                    PackageFamilyName = $"Xbox_{directoryName}",
+                    AppId = directoryName,
+                    Name = CleanGameName(gameName),
+                    InstallLocation = gameDirectory,
+                    ExecutablePath = executablePath,
+                    IsInstalled = true,
+                    Version = "Unknown",
+                    Publisher = "Unknown"
+                };
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"从Xbox目录创建游戏对象时出错: {gameDirectory} - {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// 从Xbox清单文件创建游戏对象
+        /// </summary>
+        private static XboxGame? CreateGameFromXboxManifest(string manifestPath, string gameDirectory)
+        {
+            try
+            {
+                var manifestDoc = XDocument.Load(manifestPath);
+                var ns = manifestDoc.Root?.GetDefaultNamespace();
+                
+                if (ns == null) return null;
+
+                var identity = manifestDoc.Root?.Element(ns + "Identity");
+                var properties = manifestDoc.Root?.Element(ns + "Properties");
+                var applications = manifestDoc.Root?.Element(ns + "Applications");
+
+                if (identity == null) return null;
+
+                var packageName = identity.Attribute("Name")?.Value ?? "";
+                var publisher = identity.Attribute("Publisher")?.Value ?? "";
+                var packageFamilyName = $"{packageName}_{publisher}";
+                var version = identity.Attribute("Version")?.Value ?? "1.0.0.0";
+
+                // 获取显示名称
+                var displayName = properties?.Element(ns + "DisplayName")?.Value;
+                if (string.IsNullOrEmpty(displayName))
+                {
+                    displayName = ExtractGameNameFromDirectory(gameDirectory, packageName);
+                }
+
+                // 查找可执行文件
+                var executable = applications?.Elements(ns + "Application")
+                    .FirstOrDefault()?.Attribute("Executable")?.Value;
+
+                var executablePath = "";
+                if (!string.IsNullOrEmpty(executable))
+                {
+                    executablePath = Path.Combine(gameDirectory, executable);
+                    if (!File.Exists(executablePath))
+                    {
+                        executablePath = FindXboxGameExecutable(gameDirectory, displayName);
+                    }
+                }
+                else
+                {
+                    executablePath = FindXboxGameExecutable(gameDirectory, displayName);
+                }
+
+                return new XboxGame
+                {
+                    PackageFamilyName = packageFamilyName,
+                    AppId = packageName,
+                    Name = CleanGameName(displayName),
+                    InstallLocation = gameDirectory,
+                    ExecutablePath = executablePath,
+                    IsInstalled = true,
+                    Version = version,
+                    Publisher = publisher
+                };
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"从Xbox清单创建游戏对象时出错: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// 专门查找Xbox游戏的可执行文件
+        /// </summary>
+        private static string FindXboxGameExecutable(string gamePath, string gameName)
+        {
+            try
+            {
+                if (!Directory.Exists(gamePath))
+                    return string.Empty;
+
+                var exeFiles = Directory.GetFiles(gamePath, "*.exe", SearchOption.AllDirectories);
+                if (exeFiles.Length == 0)
+                    return string.Empty;
+
+                var candidates = new List<(string path, int priority, long size)>();
+
+                foreach (var exeFile in exeFiles)
+                {
+                    var fileName = Path.GetFileNameWithoutExtension(exeFile).ToLowerInvariant();
+                    var fileInfo = new FileInfo(exeFile);
+                    var priority = 0;
+
+                    // 排除明显的非游戏文件
+                    var excludePatterns = new[]
+                    {
+                        "unins", "setup", "install", "config", "crash", "report", 
+                        "update", "patch", "tool", "util", "helper", "service",
+                        "redist", "vcredist", "directx", "dotnet"
+                    };
+
+                    if (excludePatterns.Any(pattern => fileName.Contains(pattern)))
+                        continue;
+
+                    // Xbox游戏特定的优先级计算
+                    var gameNameLower = gameName.ToLowerInvariant();
+                    
+                    if (fileName.Equals(gameNameLower))
+                        priority += 100;
+                    if (fileName.Contains(gameNameLower))
+                        priority += 50;
+                        
+                    // Xbox游戏常见的可执行文件模式
+                    var xboxGamePatterns = new[]
+                    {
+                        ("game", 30), ("main", 25), ("start", 20), ("play", 15),
+                        ("launcher", 40), ("gamelaunchhelper", 45)
+                    };
+
+                    foreach (var (pattern, score) in xboxGamePatterns)
+                    {
+                        if (fileName.Contains(pattern))
+                            priority += score;
+                    }
+
+                    // 文件大小考虑（Xbox游戏通常较大）
+                    if (fileInfo.Length > 100 * 1024 * 1024) // > 100MB
+                        priority += 25;
+                    else if (fileInfo.Length > 50 * 1024 * 1024) // > 50MB
+                        priority += 20;
+                    else if (fileInfo.Length > 10 * 1024 * 1024) // > 10MB
+                        priority += 10;
+                    else if (fileInfo.Length > 1024 * 1024) // > 1MB
+                        priority += 5;
+
+                    // 偏好在根目录或bin目录的可执行文件
+                    var relativePath = Path.GetRelativePath(gamePath, exeFile).ToLowerInvariant();
+                    if (!relativePath.Contains(Path.DirectorySeparatorChar)) // 根目录
+                        priority += 15;
+                    else if (relativePath.Contains("bin"))
+                        priority += 10;
+
+                    candidates.Add((exeFile, priority, fileInfo.Length));
+                }
+
+                if (candidates.Count == 0)
+                    return string.Empty;
+
+                // 选择优先级最高的可执行文件
+                var bestCandidate = candidates
+                    .OrderByDescending(c => c.priority)
+                    .ThenByDescending(c => c.size)
+                    .First();
+
+                System.Diagnostics.Debug.WriteLine($"为 {gameName} 选择可执行文件: {Path.GetFileName(bestCandidate.path)} (优先级: {bestCandidate.priority})");
+                return bestCandidate.path;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"查找Xbox游戏可执行文件时出错: {ex.Message}");
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// 从目录名提取游戏名称
+        /// </summary>
+        private static string ExtractGameNameFromDirectory(string gameDirectory, string directoryName)
+        {
+            try
+            {
+                // 尝试从多个来源获取更友好的游戏名称
+                
+                // 1. 检查是否有显示名称文件
+                var displayNameFiles = new[] { "DisplayName.txt", "GameName.txt", "Title.txt" };
+                foreach (var file in displayNameFiles)
+                {
+                    var filePath = Path.Combine(gameDirectory, file);
+                    if (File.Exists(filePath))
+                    {
+                        try
+                        {
+                            var content = File.ReadAllText(filePath).Trim();
+                            if (!string.IsNullOrEmpty(content))
+                                return content;
+                        }
+                        catch { }
+                    }
+                }
+
+                // 2. 尝试从包目录名称中提取（通常格式为 GameName_版本号_架构）
+                var parts = directoryName.Split('_');
+                if (parts.Length > 0)
+                {
+                    var gameName = parts[0];
+                    // 清理常见的后缀
+                    gameName = gameName.Replace("Game", "").Replace("App", "").Trim();
+                    if (!string.IsNullOrEmpty(gameName))
+                        return gameName;
+                }
+
+                // 3. 直接使用目录名
+                return directoryName;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"提取游戏名称时出错: {ex.Message}");
+                return directoryName;
+            }
+        }
+
+        /// <summary>
+        /// 扫描Xbox注册表路径
+        /// </summary>
+        private static async Task ScanXboxRegistryPathAsync(string registryPath, List<XboxGame> games, HashSet<string> foundIdentifiers)
+        {
+            try
+            {
+                using var key = Registry.CurrentUser.OpenSubKey(registryPath);
+                if (key == null) 
+                {
+                    // 也尝试LocalMachine
+                    using var lmKey = Registry.LocalMachine.OpenSubKey(registryPath);
+                    if (lmKey == null) return;
+                    
+                    await ProcessRegistryKey(lmKey, games, foundIdentifiers);
+                    return;
+                }
+
+                await ProcessRegistryKey(key, games, foundIdentifiers);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"扫描Xbox注册表路径时出错: {registryPath} - {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 处理注册表键
+        /// </summary>
+        private static async Task ProcessRegistryKey(RegistryKey key, List<XboxGame> games, HashSet<string> foundIdentifiers)
+        {
+            foreach (var subKeyName in key.GetSubKeyNames())
+            {
+                try
+                {
+                    using var subKey = key.OpenSubKey(subKeyName);
+                    if (subKey == null) continue;
+
+                    var installPath = subKey.GetValue("InstallPath") as string ?? 
+                                    subKey.GetValue("InstallLocation") as string ?? 
+                                    subKey.GetValue("GamePath") as string;
+                    
+                    if (!string.IsNullOrEmpty(installPath) && Directory.Exists(installPath))
+                    {
+                        await ScanXboxGamesInDirectoryAsync(installPath, games, foundIdentifiers);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"处理注册表子键时出错: {subKeyName} - {ex.Message}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// 获取Xbox游戏安装目录
+        /// </summary>
+        private static List<string> GetXboxInstallDirectoriesFromRegistry()
+        {
+            var directories = new List<string>();
+            
+            try
+            {
+                var registryKeys = new[]
+                {
+                    Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\GamingServices"),
+                    Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\GamingServices"),
+                    Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\GameDVR"),
+                    Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\GameDVR")
+                };
+
+                foreach (var key in registryKeys)
+                {
+                    if (key == null) continue;
+                    
+                    using (key)
+                    {
+                        // Xbox游戏默认安装位置
+                        var defaultLocation = key.GetValue("DefaultInstallLocation") as string ??
+                                             key.GetValue("XboxGamesPath") as string;
+                        if (!string.IsNullOrEmpty(defaultLocation) && Directory.Exists(defaultLocation))
+                        {
+                            directories.Add(defaultLocation);
+                        }
+
+                        // 扫描挂载点和游戏库
+                        var subKeyNames = new[] { "MountPoints", "GameLibraries", "InstallLocations" };
+                        foreach (var subKeyName in subKeyNames)
+                        {
+                            using var subKey = key.OpenSubKey(subKeyName);
+                            if (subKey != null)
+                            {
+                                foreach (var valueName in subKey.GetValueNames())
+                                {
+                                    var path = subKey.GetValue(valueName) as string;
+                                    if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
+                                    {
+                                        directories.Add(path);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"从注册表获取Xbox目录时出错: {ex.Message}");
+            }
+
+            return directories.Distinct().ToList();
+        }
+
+        /// <summary>
+        /// 获取游戏的启动参数
+        /// </summary>
+        public static string GetGameLaunchArguments(XboxGame game)
+        {
+            if (string.IsNullOrEmpty(game.PackageFamilyName))
+                return string.Empty;
+
+            return $"shell:appsFolder\\{game.PackageFamilyName}!App";
+        }
+
+        /// <summary>
+        /// 检查游戏是否正在运行
+        /// </summary>
+        public static bool IsGameRunning(XboxGame game)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(game.ExecutablePath))
+                    return false;
+
+                var processName = Path.GetFileNameWithoutExtension(game.ExecutablePath);
+                var processes = Process.GetProcessesByName(processName);
+                
+                return processes.Length > 0;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"检查游戏运行状态时出错: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// 启动 Xbox 游戏
+        /// </summary>
+        public static bool LaunchXboxGame(string packageFamilyName)
+        {
+            try
+            {
+                // 使用 Windows 应用协议启动游戏
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "explorer.exe",
+                    Arguments = $"shell:appsFolder\\{packageFamilyName}!App",
+                    UseShellExecute = true
+                };
+
+                Process.Start(startInfo);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"启动 Xbox 游戏时出错: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// 通过可执行文件启动游戏（备选方案）
+        /// </summary>
+        public static bool LaunchXboxGameByExecutable(string executablePath)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(executablePath) || !File.Exists(executablePath))
+                {
+                    return false;
+                }
+
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = executablePath,
+                    WorkingDirectory = Path.GetDirectoryName(executablePath) ?? string.Empty,
+                    UseShellExecute = true
+                };
+
+                Process.Start(startInfo);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"通过可执行文件启动 Xbox 游戏时出错: {ex.Message}");
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
#5 

在 `CustomDataObject.cs` 中添加了 `XboxPackageFamilyName` 和 `IsXboxGame` 属性，更新文档注释以支持 Xbox 游戏。 在 `GamesPage.xaml` 中将导入游戏按钮更改为下拉按钮，支持导入 Steam 和 Xbox 游戏。 在 `GamesPage.xaml.cs` 中移除与 Steam 游戏导入相关的逻辑，添加 Xbox 游戏导入功能。 在 `XboxServiceExample.cs` 中添加示例类以展示 Xbox 服务的使用。
在 `UwpApp.cs` 中定义 `UwpApp` 类以表示 UWP 应用信息。
在 `Programs.cs` 中添加获取已安装 UWP 应用的功能。
在 `XboxService.cs` 中实现 Xbox 游戏的扫描、信息获取和启动功能，全面支持 Xbox 游戏管理。